### PR TITLE
Allow dataframes with only one row and non-zero index to be written.

### DIFF
--- a/starfile/writer.py
+++ b/starfile/writer.py
@@ -128,7 +128,7 @@ class StarWriter:
         self.buffer.append_to_file_and_clear(self.filename)
 
     def _write_simple_block(self, df: pd.DataFrame):
-        lines = [f'_{column_name}\t\t\t{df[column_name][0]}'
+        lines = [f'_{column_name}\t\t\t{df[column_name][df.index[0]]}'
                  for column_name in df.columns]
         for line in lines:
             self.buffer.add_line(line)

--- a/starfile/writer.py
+++ b/starfile/writer.py
@@ -128,7 +128,7 @@ class StarWriter:
         self.buffer.append_to_file_and_clear(self.filename)
 
     def _write_simple_block(self, df: pd.DataFrame):
-        lines = [f'_{column_name}\t\t\t{df[column_name][df.index[0]]}'
+        lines = [f'_{column_name}\t\t\t{df[column_name].iloc[0]}'
                  for column_name in df.columns]
         for line in lines:
             self.buffer.add_line(line)

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -1,3 +1,6 @@
+from os.path import join as join_path
+from tempfile import TemporaryDirectory
+
 import pandas as pd
 
 from starfile.parser import StarParser
@@ -46,3 +49,20 @@ def test_create_from_dataframes():
 
     s = StarParser(output_file)
     assert len(s.dataframes) == 2
+
+def test_can_write_non_zero_indexed_one_row_dataframe():
+    df = pd.DataFrame([[1,2,3]], columns=["A", "B", "C"])
+    df.index += 1
+
+    with TemporaryDirectory() as directory:
+        filename = join_path(directory, "test.star")
+        StarWriter(df, filename)
+        with open(filename) as output_file:
+            output = output_file.read()
+
+    expected = (
+        "_A\t\t\t1\n"
+        "_B\t\t\t2\n"
+        "_C\t\t\t3\n"
+    )
+    assert (expected in output)

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -51,6 +51,7 @@ def test_create_from_dataframes():
     assert len(s.dataframes) == 2
 
 def test_can_write_non_zero_indexed_one_row_dataframe():
+    # see PR #13 - https://github.com/alisterburt/starfile/pull/13
     df = pd.DataFrame([[1,2,3]], columns=["A", "B", "C"])
     df.index += 1
 


### PR DESCRIPTION
Hi @alisterburt 

I've fixed what I think is a bug (not 100% sure).

The previous code assumed that the topmost row of a data-frame must be
indexed by zero. This is not always the case - for example if we have
filtered out entries before saving.

Let me know if the test isn't quite in the form you like.