### PR TITLE
NaN and SEP arguments and handling for writing

### DIFF
--- a/starfile/functions.py
+++ b/starfile/functions.py
@@ -21,14 +21,14 @@ def open(filename: str, read_n_blocks: int = None, always_dict: bool = False):
 
 
 def new(data: Union[pd.DataFrame, Dict[str, pd.DataFrame], List[pd.DataFrame]], filename: str,
-        float_format: str = '%.6f', sep: str = '\t', overwrite: bool = False):
+        float_format: str = '%.6f', sep: str = '\t', na_rep: str = '<NA>', overwrite: bool = False):
     """
     Write dataframes from pandas dataframe(s) to a star file
 
     data can be a single dataframe, a list of dataframes or a dict of dataframes
     float format defaults to 6 digits after the decimal point
     """
-    StarWriter(data, filename=filename, float_format=float_format, sep=sep, overwrite=overwrite)
+    StarWriter(data, filename=filename, float_format=float_format, sep=sep, na_rep=na_rep, overwrite=overwrite)
 
 
 read = open

--- a/starfile/functions.py
+++ b/starfile/functions.py
@@ -20,34 +20,16 @@ def open(filename: str, read_n_blocks: int = None, always_dict: bool = False):
         return star.dataframes
 
 
-def read(filename: str, read_n_blocks: int = None, always_dict: bool = False):
-    """
-    Read a star file into a pandas dataframe or dict of pandas dataframes
-
-    default behaviour in the case of only one data block being present in the STAR file is to
-    return only a dataframe, this can be changed by setting 'always_dict=True'
-    """
-    return open(filename, read_n_blocks=read_n_blocks, always_dict=always_dict)
-
-
 def new(data: Union[pd.DataFrame, Dict[str, pd.DataFrame], List[pd.DataFrame]], filename: str,
-        float_format: str = '%.6f', overwrite: bool = False):
+        float_format: str = '%.6f', sep: str = '\t', overwrite: bool = False):
     """
     Write dataframes from pandas dataframe(s) to a star file
 
     data can be a single dataframe, a list of dataframes or a dict of dataframes
     float format defaults to 6 digits after the decimal point
     """
-    StarWriter(data, filename=filename, float_format=float_format, overwrite=overwrite)
-    return
+    StarWriter(data, filename=filename, float_format=float_format, sep=sep, overwrite=overwrite)
 
 
-def write(data: Union[pd.DataFrame, Dict[str, pd.DataFrame], List[pd.DataFrame]], filename: str,
-          float_format: str = '%.6f', overwrite: bool = False):
-    """
-    Write dataframes from pandas dataframe(s) to a star file
-
-    data can be a single dataframe, a list of dataframes or a dict of dataframes
-    float format defaults to 6 digits after the decimal point
-    """
-    new(data, filename=filename, float_format=float_format, overwrite=overwrite)
+read = open
+write = new

--- a/starfile/writer.py
+++ b/starfile/writer.py
@@ -11,11 +11,12 @@ from .version import __version__
 
 class StarWriter:
     def __init__(self, dataframes: Union[pd.DataFrame, dict, list], filename: Union[Path, str],
-                 overwrite=False, float_format='%.6f'):
+                 overwrite=False, float_format='%.6f', sep='\t'):
         self.overwrite = overwrite
         self.filename = filename
         self.dataframes = dataframes
         self.float_format = float_format
+        self.sep = sep
         self.buffer = TextBuffer()
         self.write_star_file()
 
@@ -136,6 +137,6 @@ class StarWriter:
 
     def _write_loop_block(self, df: pd.DataFrame):
         self.write_loopheader(df)
-        df.to_csv(self.filename, mode='a', sep='\t', header=False, index=False,
+        df.to_csv(self.filename, mode='a', sep=self.sep, header=False, index=False,
                   float_format=self.float_format)
 

--- a/starfile/writer.py
+++ b/starfile/writer.py
@@ -11,12 +11,13 @@ from .version import __version__
 
 class StarWriter:
     def __init__(self, dataframes: Union[pd.DataFrame, dict, list], filename: Union[Path, str],
-                 overwrite=False, float_format='%.6f', sep='\t'):
+                 overwrite=False, float_format='%.6f', sep='\t', na_rep='<NA>'):
         self.overwrite = overwrite
         self.filename = filename
         self.dataframes = dataframes
         self.float_format = float_format
         self.sep = sep
+        self.na_rep = na_rep
         self.buffer = TextBuffer()
         self.write_star_file()
 
@@ -138,5 +139,5 @@ class StarWriter:
     def _write_loop_block(self, df: pd.DataFrame):
         self.write_loopheader(df)
         df.to_csv(self.filename, mode='a', sep=self.sep, header=False, index=False,
-                  float_format=self.float_format)
+                  float_format=self.float_format, na_rep=self.na_rep)
 


### PR DESCRIPTION
This PR adds the ability to set a custom string for separator and for NAN values when writing to file. It also defaults NAN strings to `<NA>`, instead of an empty string, which broke column separation.

PS: also removed that code duplication in functions :P